### PR TITLE
fix a small bug in DummyHistoryHandler.java(proj2a)

### DIFF
--- a/proj2a/src/main/DummyHistoryHandler.java
+++ b/proj2a/src/main/DummyHistoryHandler.java
@@ -22,12 +22,12 @@ public class DummyHistoryHandler extends NgordnetQueryHandler {
                         "actually use the query data.");
 
         TimeSeries parabola = new TimeSeries();
-        for (int i = 1400; i < 1500; i += 1) {
+        for (int i = 0; i < 100; i += 1) {
             parabola.put(i, (i - 50.0) * (i - 50.0) + 3);
         }
 
         TimeSeries sinWave = new TimeSeries();
-        for (int i = 1400; i < 1500; i += 1) {
+        for (int i = 0; i < 100; i += 1) {
             sinWave.put(i, 1000 + 500 * Math.sin(i/100.0*2*Math.PI));
         }
 


### PR DESCRIPTION
I am a student from China. While working on proj2a, I found that the provided skeleton code did not produce the parabola and sinusoid as demonstrated in the documentation. Therefore, I modified this bug to achieve the correct demonstration.

The original code is as follows:
```java
TimeSeries parabola = new TimeSeries();
for (int i = 1400; i < 1500; i += 1) {
    parabola.put(i, (i - 50.0) * (i - 50.0) + 3);
}
TimeSeries sinWave = new TimeSeries();
for (int i = 1400; i < 1500; i += 1) {
    sinWave.put(i, 1000 + 500 * Math.sin(i/100.0*2*Math.PI));
}
```

The image is as follows:
![image](https://github.com/user-attachments/assets/f082b122-6687-4e99-94cb-f340c6f3d133)

After modifying the code, it is as follows:
```java
TimeSeries parabola = new TimeSeries();
for (int i = 0; i < 100; i += 1) {
    parabola.put(i, (i - 50.0) * (i - 50.0) + 3);
}
TimeSeries sinWave = new TimeSeries();
for (int i = 0; i < 100; i += 1) {
    sinWave.put(i, 1000 + 500 * Math.sin(i/100.0*2*Math.PI));
}
```

The image is as follows:
![image](https://github.com/user-attachments/assets/2ab90d18-1098-42d4-86db-a60d30962445)

I would like to thank Berkeley, the professors, and the TAs for providing such great learning materials in CS61B.
