### PR TITLE
fix: use the correct key to search the value

### DIFF
--- a/lab06/src/ULLMap.java
+++ b/lab06/src/ULLMap.java
@@ -88,7 +88,7 @@ public class ULLMap<K, V>  implements Map61B<K, V> {
             if (next == null) {
                 return null;
             }
-            return next.get(key);
+            return next.get(k);
         }
 
         /** Stores the key of the key-value pair of this node in the list. */


### PR DESCRIPTION
Because it uses the key to search for the entry, it always searches for the first entry’s key instead of the specified k.
If you want me to add an unit test, I'm glad to add it.
```java
public static void main(String[] args) {
        ULLMap<String, Integer> map = new ULLMap<>();
        map.put("Jennie", 24);
        map.put("Rustin", 28);
        System.out.println(map.get("Jennie"));
}
```
Before I correct this problem, it always prints null. After correction, it prints out 24.